### PR TITLE
Threads number liveness probe support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM python:3-slim
 WORKDIR /opt/clairttn
 COPY . .
 RUN pip3 install .
+HEALTHCHECK --interval=5s --timeout=1s --retries=3 \
+    CMD test -s "/tmp/clair-alive"
 CMD clair-ttn

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3-slim
 WORKDIR /opt/clairttn
 COPY . .
 RUN pip3 install .
+# interval must be longer than the sleep period in clairttn.py
 HEALTHCHECK --interval=5s --timeout=1s --retries=3 \
-    CMD test -s "/tmp/clair-alive"
+    CMD ./healthcheck.sh
 CMD clair-ttn

--- a/clairttn/scripts/clairttn.py
+++ b/clairttn/scripts/clairttn.py
@@ -98,5 +98,7 @@ def main(app_id, access_key_file, mode, api_root, stack):
 
     while not signal_received:
         time.sleep(1)
+        with open('/tmp/clair-ttn-active-threads', 'w') as f:
+            f.write("{}\n".format(threading.active_count()))
 
     node_handler.disconnect_and_close()

--- a/clairttn/scripts/clairttn.py
+++ b/clairttn/scripts/clairttn.py
@@ -10,6 +10,7 @@ logger.addHandler(logging.StreamHandler())
 import click
 import signal
 import time
+import threading
 import clairttn.node_handler as clhandler
 import clairttn.ttn_handler as ttnhandler
 
@@ -98,6 +99,9 @@ def main(app_id, access_key_file, mode, api_root, stack):
 
     while not signal_received:
         time.sleep(1)
+        # Health-check of the MQTT background thread:
+        # Write a file if both the present foreground thread and the background thread
+        # exist; i.e., if the MQTT background thread has not crashed.
         if threading.active_count() == 2:
             with open('/tmp/clair-alive', 'w') as f:
                 f.write("alive\n")

--- a/clairttn/scripts/clairttn.py
+++ b/clairttn/scripts/clairttn.py
@@ -98,7 +98,8 @@ def main(app_id, access_key_file, mode, api_root, stack):
 
     while not signal_received:
         time.sleep(1)
-        with open('/tmp/clair-ttn-active-threads', 'w') as f:
-            f.write("{}\n".format(threading.active_count()))
+        if threading.active_count() == 2:
+            with open('/tmp/clair-alive', 'w') as f:
+                f.write("alive\n")
 
     node_handler.disconnect_and_close()

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+MARKER_FILE="/tmp/clair-alive"
+if [ -s $MARKER_FILE ]
+then
+    echo "Background thread was alive.";
+    rm $MARKER_FILE
+    exit 0
+else
+    echo "Background thread seems to be dead.";
+    exit 1
+fi

--- a/—
+++ b/—
@@ -1,0 +1,1 @@
+Rebase on master with MQTT support for TTNv2 and TTNv3 


### PR DESCRIPTION
This PR addresses our well-known reconnect failure issue in a built-to-fail manner.

The TTN python library is designed to support a reconnect mechanism, which is enabled by default. The problem is that the MQTT connection loop runs in a background thread and an exception caused by a reconnect attempt (which is our usual pattern) is uncaught.

This PR does not try to fix the TTN library. Instead the *main thread* monitors the number of active threads and writes a file into the /tmp directory if the MQTT background thread is running. This is done once per second.

A (kubernetes) liveness probe should force-delete the file and wait for a couple of seconds. If the file reappears the service is assumed to be alive.